### PR TITLE
Add `kind` to `Email.Attachment` to allow adding inline-attachments.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.78.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.24.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.29.0"),
@@ -38,6 +39,7 @@ let package = Package(
         .target(
             name: "SwiftSMTP",
             dependencies: [
+                .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOExtras", package: "swift-nio-extras"),

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -32,6 +32,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.43.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.14.0"),
@@ -43,6 +44,7 @@ let package = Package(
         .target(
             name: "SwiftSMTP",
             dependencies: [
+                .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOExtras", package: "swift-nio-extras"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -29,6 +29,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.43.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.14.0"),
@@ -40,6 +41,7 @@ let package = Package(
         .target(
             name: "SwiftSMTP",
             dependencies: [
+                .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOExtras", package: "swift-nio-extras"),

--- a/Sources/SwiftSMTP/Mailer.swift
+++ b/Sources/SwiftSMTP/Mailer.swift
@@ -117,7 +117,12 @@ public final class Mailer: @unchecked Sendable {
                         SMTPHandler(configuration: configuration, email: email.email, allDonePromise: email.promise),
                     ]
                     if let logger = transmissionLogger {
-                        handlers.insert(LogDuplexHandler(logger: logger), at: handlers.startIndex)
+                        func makeLogHandler<Logger: SMTPLogger>(_ logger: Logger) -> LogDuplexHandler<Logger> {
+                            LogDuplexHandler(logger: logger)
+                        }
+                        // TODO: Shouldn't this be handled by Swift nowadays?
+                        let logHandler = _openExistential(logger, do: makeLogHandler)
+                        handlers.insert(logHandler, at: handlers.startIndex)
                     }
                     switch try configuration.server.createEncryptionHandlers() {
                     case nil: break

--- a/Sources/SwiftSMTP/Models/Configuration.swift
+++ b/Sources/SwiftSMTP/Models/Configuration.swift
@@ -93,9 +93,9 @@ extension Configuration.Server {
         case startTLS(StartTLSMode)
 
         /// The default port for this encryption:
-        /// - plain: 25
-        /// - ssl: 465
-        /// - startTLS: 587
+        /// - ``plain``: `25`
+        /// - ``ssl``: `465`
+        /// - ``startTLS(_:)``: `587`
         public var defaultPort: Int {
             switch self {
             case .plain: return 25
@@ -117,7 +117,7 @@ extension Configuration.Server.Encryption {
 }
 
 extension Configuration.FeatureFlags {
-    /// Whether ESMTP should be used (e.g. send EHLO instead of HELO).
+    /// Whether ESMTP should be used (e.g. send `EHLO` instead of `HELO`).
     public static let useESMTP = Configuration.FeatureFlags(rawValue: 1 << 0)
 
     /// Whether all messages sent to the server should be using base64 (transfer) encoding. Use further options to customize the line length.

--- a/Sources/SwiftSMTP/Models/Email.swift
+++ b/Sources/SwiftSMTP/Models/Email.swift
@@ -121,6 +121,24 @@ extension Email {
         public var contentType: String
         /// The data of the attachment.
         public var data: Data
+        /// The content id of the attachment.
+        /// This can be used for referencing the attachment in the email body.
+        /// Note that the content id must be unique.
+        /// The recommended format is to use `<some-generated-value>@domain.example.com`.
+        public var contentID: String?
+
+        /// Creates a new email attachment with the given parameters.
+        /// - Parameters:
+        ///   - name: The (file) name of the attachment.
+        ///   - contentType: The content type of the attachment.
+        ///   - data: The data of the attachment.
+        ///   - contentID: The content id of the attachment.
+        public init(name: String, contentType: String, data: Data, contentID: String?) {
+            self.name = name
+            self.contentType = contentType
+            self.data = data
+            self.contentID = contentID
+        }
 
         /// Creates a new email attachment with the given parameters.
         /// - Parameters:
@@ -128,9 +146,17 @@ extension Email {
         ///   - contentType: The content type of the attachment.
         ///   - data: The data of the attachment.
         public init(name: String, contentType: String, data: Data) {
-            self.name = name
-            self.contentType = contentType
-            self.data = data
+            self.init(name: name, contentType: contentType, data: data, contentID: nil)
+        }
+
+        /// Creates a new email attachment with the given parameters.
+        /// - Parameters:
+        ///   - name: The (file) name of the attachment.
+        ///   - contentType: The content type of the attachment.
+        ///   - contents: The contents of the attachment.
+        ///   - contentID: The content id of the attachment.
+        public init(name: String, contentType: String, contents: ByteBuffer, contentID: String?) {
+            self.init(name: name, contentType: contentType, data: Data(contents.readableBytesView), contentID: contentID)
         }
 
         /// Creates a new email attachment with the given parameters.
@@ -139,7 +165,7 @@ extension Email {
         ///   - contentType: The content type of the attachment.
         ///   - contents: The contents of the attachment.
         public init(name: String, contentType: String, contents: ByteBuffer) {
-            self.init(name: name, contentType: contentType, data: Data(contents.readableBytesView))
+            self.init(name: name, contentType: contentType, contents: contents, contentID: nil)
         }
     }
 }

--- a/Sources/SwiftSMTP/Models/NetworkModels.swift
+++ b/Sources/SwiftSMTP/Models/NetworkModels.swift
@@ -1,3 +1,13 @@
+#if swift(>=6.0)
+import Foundation
+#else
+#if canImport(Darwin)
+public import Foundation
+#else
+@preconcurrency public import Foundation
+#endif
+#endif
+
 enum SMTPRequest: Sendable {
     case sayHello(serverName: String, useEHello: Bool)
     case startTLS
@@ -7,7 +17,7 @@ enum SMTPRequest: Sendable {
     case mailFrom(String)
     case recipient(String)
     case data
-    case transferData(Email)
+    case transferData(date: Date, email: Email)
     case quit
 }
 

--- a/Sources/SwiftSMTP/NIO Channel Handlers/LogDuplexHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/LogDuplexHandler.swift
@@ -16,7 +16,7 @@ public protocol SMTPLogger: Sendable {
 /// A simple SMTP logger that logs messages using `Swift.print`.
 @frozen
 public struct PrintSMTPLogger: SMTPLogger {
-    /// Creates a new PrintSMTPLogger.
+    /// Creates a new ``PrintSMTPLogger``.
     @inlinable
     public init() {}
 
@@ -26,15 +26,15 @@ public struct PrintSMTPLogger: SMTPLogger {
     }
 }
 
-final class LogDuplexHandler: Sendable, ChannelDuplexHandler {
+final class LogDuplexHandler<Logger: SMTPLogger>: Sendable, ChannelDuplexHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 
-    let logger: any SMTPLogger
+    let logger: Logger
 
-    init(logger: any SMTPLogger) {
+    init(logger: Logger) {
         self.logger = logger
     }
 

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
@@ -1,6 +1,8 @@
 #if swift(>=6.0)
+import Foundation
 import NIO
 #else
+public import Foundation
 public import NIO
 #endif
 import NIOExtras
@@ -104,7 +106,7 @@ final class SMTPHandler: ChannelInboundHandler {
         case .recipientSent(var iterator):
             state = nextState(for: &iterator)
         case .dataCommandSent:
-            send(command: .transferData(email))
+            send(command: .transferData(date: Date(), email: email))
             state = .mailDataSent
         case .mailDataSent:
             send(command: .quit)

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
@@ -54,7 +54,9 @@ struct SMTPRequestEncoder: MessageToByteEncoder {
         return attachments.lazy.map {
             """
             \(contentTypeHeaders($0.contentType, usesBase64: true))\r\n\
-            Content-Disposition: attachment; filename="\($0.name)"\r\n\r\n\
+            Content-Disposition: attachment; filename="\($0.name)"\r\n\
+            \($0.contentID.map { "Content-ID: <\($0)>" } ?? "")
+            \r\n\
             \($0.data.base64EncodedString(options: base64EncodingOptions))\r\n
             """
         }.joined(separator: "\r\n--\(boundary)\r\n")

--- a/Sources/SwiftSMTPCLI/main.swift
+++ b/Sources/SwiftSMTPCLI/main.swift
@@ -47,15 +47,15 @@ let email = Email(sender: .init(name: "SwiftSMTP CLI", emailAddress: "swiftsmtp@
                   body: .universal(plain: plainText, html: htmlText),
                   attachments: [
                     // Taken from https://icons.getbootstrap.com/icons/emoji-smile
-                    .init(name: "bi-emoji-smile.svg",
+                    .init(kind: .inline(contentID: imageContentId),
+                          name: "bi-emoji-smile.svg",
                           contentType: "image/svg+xml",
                           data: Data("""
                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-smile" viewBox="0 0 16 16">
                                        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
                                        <path d="M4.285 9.567a.5.5 0 0 1 .683.183A3.5 3.5 0 0 0 8 11.5a3.5 3.5 0 0 0 3.032-1.75.5.5 0 1 1 .866.5A4.5 4.5 0 0 1 8 12.5a4.5 4.5 0 0 1-3.898-2.25.5.5 0 0 1 .183-.683M7 6.5C7 7.328 6.552 8 6 8s-1-.672-1-1.5S5.448 5 6 5s1 .672 1 1.5m4 0c0 .828-.448 1.5-1 1.5s-1-.672-1-1.5S9.448 5 10 5s1 .672 1 1.5"/>
                                      </svg>
-                                     """.utf8),
-                          contentID: imageContentId),
+                                     """.utf8)),
                     .init(name: "Test.txt",
                           contentType: #"text/plain; charset="UTF-8""#,
                           data: Data("This is simple text file\nwith two lines...".utf8)),

--- a/Sources/SwiftSMTPCLI/main.swift
+++ b/Sources/SwiftSMTPCLI/main.swift
@@ -17,6 +17,7 @@ Hi there,
 this is a test mail from SwiftSMTP CLI.
 
 :-)
+[cid:\(imageContentId)]
 
 Have a nice day!
 """

--- a/Sources/SwiftSMTPCLI/main.swift
+++ b/Sources/SwiftSMTPCLI/main.swift
@@ -10,10 +10,13 @@ let config = Configuration(server: .init(hostname: "mail.server.com",
                                               password: "password"),
                            featureFlags: [.base64EncodeAllMessages, .maximumBase64LineLength64])
 
+let imageContentId = "\(UUID().uuidString)@\(config.server.hostname)"
 let plainText = """
 Hi there,
 
 this is a test mail from SwiftSMTP CLI.
+
+:-)
 
 Have a nice day!
 """
@@ -28,6 +31,7 @@ let htmlText = """
 <body>
 <p>Hi there,</p>
 <p>this is a test mail from SwiftSMTP CLI.</p>
+<img src="cid:\(imageContentId.replacingOccurrences(of: #"""#, with: #"\""#))" alt="Smiling Face"/>
 <p>Have a nice day!</p>
 </body>
 </html>
@@ -42,9 +46,19 @@ let email = Email(sender: .init(name: "SwiftSMTP CLI", emailAddress: "swiftsmtp@
                   subject: "Testing SwiftSMTP from CLI",
                   body: .universal(plain: plainText, html: htmlText),
                   attachments: [
+                    // Taken from https://icons.getbootstrap.com/icons/emoji-smile
+                    .init(name: "bi-emoji-smile.svg",
+                          contentType: "image/svg+xml",
+                          data: Data("""
+                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-smile" viewBox="0 0 16 16">
+                                       <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
+                                       <path d="M4.285 9.567a.5.5 0 0 1 .683.183A3.5 3.5 0 0 0 8 11.5a3.5 3.5 0 0 0 3.032-1.75.5.5 0 1 1 .866.5A4.5 4.5 0 0 1 8 12.5a4.5 4.5 0 0 1-3.898-2.25.5.5 0 0 1 .183-.683M7 6.5C7 7.328 6.552 8 6 8s-1-.672-1-1.5S5.448 5 6 5s1 .672 1 1.5m4 0c0 .828-.448 1.5-1 1.5s-1-.672-1-1.5S9.448 5 10 5s1 .672 1 1.5"/>
+                                     </svg>
+                                     """.utf8),
+                          contentID: imageContentId),
                     .init(name: "Test.txt",
                           contentType: #"text/plain; charset="UTF-8""#,
-                          data: Data("This is simple text file\nwith two lines...".utf8))
+                          data: Data("This is simple text file\nwith two lines...".utf8)),
                   ])
 
 let evg = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)

--- a/Tests/SwiftSMTPTests/LogDuplexHandlerTests.swift
+++ b/Tests/SwiftSMTPTests/LogDuplexHandlerTests.swift
@@ -1,0 +1,61 @@
+#if swift(>=6.0)
+import Testing
+import Foundation
+import NIO
+import NIOConcurrencyHelpers
+@testable import SwiftSMTP
+
+@Suite
+struct LogDuplexHandlerTests {
+    private final class TestLogger: SMTPLogger {
+        private let messages = NIOLockedValueBox(Array<String>())
+
+        var currentMessages: Array<String> { messages.withLockedValue(\.self) }
+
+        func logSMTPMessage(_ message: @autoclosure () -> String) {
+            messages.withLockedValue { $0.append(message()) }
+        }
+    }
+
+
+    @Test
+    func inbound() async throws {
+        let handler = LogDuplexHandler(logger: TestLogger())
+        let channel = EmbeddedChannel()
+        try await channel.pipeline.addHandler(handler)
+        try channel.writeInbound(ByteBuffer(string: "Inbound Message"))
+        channel.flush()
+        try await channel.close()
+
+        #expect(handler.logger.currentMessages == ["☁️ Inbound Message"])
+    }
+
+    @Test
+    func outbound() async throws {
+        let handler = LogDuplexHandler(logger: TestLogger())
+        let channel = EmbeddedChannel()
+        try await channel.pipeline.addHandler(handler)
+        try channel.writeOutbound(ByteBuffer(string: "Outbound Message"))
+        channel.flush()
+        try await channel.close()
+
+        #expect(handler.logger.currentMessages == ["💻 Outbound Message"])
+    }
+
+    @Test
+    func bidirectional() async throws {
+        let handler = LogDuplexHandler(logger: TestLogger())
+        let channel = EmbeddedChannel()
+        try await channel.pipeline.addHandler(handler)
+        try channel.writeInbound(ByteBuffer(string: "Inbound Message"))
+        try channel.writeOutbound(ByteBuffer(string: "Outbound Message"))
+        channel.flush()
+        try await channel.close()
+
+        #expect(handler.logger.currentMessages == [
+            "☁️ Inbound Message",
+            "💻 Outbound Message",
+        ])
+    }
+}
+#endif

--- a/Tests/SwiftSMTPTests/PreSwift6Stub.swift
+++ b/Tests/SwiftSMTPTests/PreSwift6Stub.swift
@@ -1,8 +1,8 @@
+#if swift(<6.0)
 import XCTest
 @testable import SwiftSMTP
 
 final class SwiftSMTPTests: XCTestCase {
-    func testExample() {
-        // TODO
-    }
+    func testNothing() {}
 }
+#endif

--- a/Tests/SwiftSMTPTests/SMTPRequestEncoderTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPRequestEncoderTests.swift
@@ -1,0 +1,224 @@
+#if swift(>=6.0)
+import RegexBuilder
+import Testing
+import Foundation
+import NIO
+@testable import SwiftSMTP
+
+@Suite
+struct SMTPRequestEncoderTests {
+    private func encodeRequest(_ request: SMTPRequest,
+                               base64EncodeAllMessages: Bool,
+                               base64EncodingOptions: Data.Base64EncodingOptions) throws -> String {
+        let encoder = SMTPRequestEncoder(base64EncodeAllMessages: base64EncodeAllMessages,
+                                         base64EncodingOptions: base64EncodingOptions)
+        var byteBuffer = ByteBufferAllocator().buffer(capacity: 1024)
+        try encoder.encode(data: request, out: &byteBuffer)
+        return byteBuffer.readString(length: byteBuffer.readableBytes) ?? ""
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func sayHello(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let server = "mail.server.tld"
+        let ehello = try encodeRequest(.sayHello(serverName: server, useEHello: true),
+                                       base64EncodeAllMessages: base64EncodeAllMessages,
+                                       base64EncodingOptions: base64EncodingOptions)
+        let normalHello = try encodeRequest(.sayHello(serverName: server, useEHello: false),
+                                            base64EncodeAllMessages: base64EncodeAllMessages,
+                                            base64EncodingOptions: base64EncodingOptions)
+        #expect(ehello == "EHLO \(server)\r\n")
+        #expect(normalHello == "HELO \(server)\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func startTLS(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let encoded = try encodeRequest(.startTLS,
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "STARTTLS\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func beginAuthentication(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let encoded = try encodeRequest(.beginAuthentication,
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "AUTH LOGIN\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func authUser(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let encoded = try encodeRequest(.authUser("my.user@example.com"),
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "bXkudXNlckBleGFtcGxlLmNvbQ==\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func authPassword(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let encoded = try encodeRequest(.authPassword("jB)7ie$sJ)Q8mXN@^ZR8RybVP!FDvwXG"),
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "akIpN2llJHNKKVE4bVhOQF5aUjhSeWJWUCFGRHZ3WEc=\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func mailFrom(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let email = "some.sender@example.com"
+        let encoded = try encodeRequest(.mailFrom(email),
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "MAIL FROM:<\(email)>\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func mailTo(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let email = "some.receiver@example.com"
+        let encoded = try encodeRequest(.recipient(email),
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "RCPT TO:<\(email)>\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func data(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let encoded = try encodeRequest(.data,
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "DATA\r\n")
+    }
+
+    @Test(arguments: [true, false], [Data.Base64EncodingOptions.lineLength64Characters, .lineLength76Characters])
+    func quit(base64EncodeAllMessages: Bool, base64EncodingOptions: Data.Base64EncodingOptions) async throws {
+        let encoded = try encodeRequest(.quit,
+                                        base64EncodeAllMessages: base64EncodeAllMessages,
+                                        base64EncodingOptions: base64EncodingOptions)
+        #expect(encoded == "QUIT\r\n")
+    }
+
+    @Test
+    func transferPlainTextOnly() async throws {
+        let senderServerName = "example.com"
+        let sender = Email.Contact(name: "Sender Name", emailAddress: "some.sender@\(senderServerName)")
+        let receiver = Email.Contact(name: "Receiver Name", emailAddress: "some.receiver@example.com")
+        let subject = "Test Message"
+        let plainTextBody = "The contents of this email\nare very simple and just for testing..."
+        let date = Date(timeIntervalSince1970: 1744193604) // 2025-04-09T10:13:24Z
+        let encoded = try encodeRequest(.transferData(date: date,
+                                                      email: .init(sender: sender,
+                                                                   recipients: [receiver],
+                                                                   subject: subject,
+                                                                   body: .plain(plainTextBody))),
+                                        base64EncodeAllMessages: false,
+                                        base64EncodingOptions: [])
+        #expect(encoded == """
+            From: "\(sender.name ?? "")" <\(sender.emailAddress)>\r\n\
+            To: "\(receiver.name ?? "")" <\(receiver.emailAddress)>\r\n\
+            Date: \(date.formattedForSMTP)\r\n\
+            Message-ID: <\(date.timeIntervalSince1970)@\(senderServerName)>\r\n\
+            Subject: \(subject)\r\n\
+            MIME-Version: 1.0\r\n\
+            Content-Type: text/plain; charset="UTF-8"\r\n\r\n\
+            \(plainTextBody)\r\n\
+            \r\n.\r\n
+            """)
+    }
+
+    @Test
+    func transferHTMLOnly() async throws {
+        let senderServerName = "example.com"
+        let sender = Email.Contact(name: "Sender Name", emailAddress: "some.sender@\(senderServerName)")
+        let receiver = Email.Contact(name: "Receiver Name", emailAddress: "some.receiver@example.com")
+        let subject = "Test Message"
+        let htmlBody = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+            <meta charset="utf-8" />
+            <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+            </head>
+            <body>
+            <p>This is a test.</p>
+            <p>Nothing more but a test.</p>
+            </body>
+            </html>
+            """
+        let date = Date(timeIntervalSince1970: 1744193604) // 2025-04-09T10:13:24Z
+        let encoded = try encodeRequest(.transferData(date: date,
+                                                      email: .init(sender: sender,
+                                                                   recipients: [receiver],
+                                                                   subject: subject,
+                                                                   body: .html(htmlBody))),
+                                        base64EncodeAllMessages: false,
+                                        base64EncodingOptions: [])
+        #expect(encoded == """
+                From: "\(sender.name ?? "")" <\(sender.emailAddress)>\r\n\
+                To: "\(receiver.name ?? "")" <\(receiver.emailAddress)>\r\n\
+                Date: \(date.formattedForSMTP)\r\n\
+                Message-ID: <\(date.timeIntervalSince1970)@\(senderServerName)>\r\n\
+                Subject: \(subject)\r\n\
+                MIME-Version: 1.0\r\n\
+                Content-Type: text/html; charset="UTF-8"\r\n\r\n\
+                \(htmlBody)\r\n\
+                \r\n.\r\n
+                """)
+    }
+
+    @Test
+    func transferUniversal() async throws {
+        let senderServerName = "example.com"
+        let sender = Email.Contact(name: "Sender Name", emailAddress: "some.sender@\(senderServerName)")
+        let receiver = Email.Contact(name: "Receiver Name", emailAddress: "some.receiver@example.com")
+        let subject = "Test Message"
+        let plainTextBody = "The contents of this email\nare very simple and just for testing..."
+        let htmlBody = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+            <meta charset="utf-8" />
+            <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+            </head>
+            <body>
+            <p>This is a test.</p>
+            <p>Nothing more but a test.</p>
+            </body>
+            </html>
+            """
+        let date = Date(timeIntervalSince1970: 1744193604) // 2025-04-09T10:13:24Z
+        let encoded = try encodeRequest(.transferData(date: date,
+                                                      email: .init(sender: sender,
+                                                                   recipients: [receiver],
+                                                                   subject: subject,
+                                                                   body: .universal(plain: plainTextBody, html: htmlBody))),
+                                        base64EncodeAllMessages: false,
+                                        base64EncodingOptions: [])
+        let regex = Regex {
+            """
+            From: "\(sender.name ?? "")" <\(sender.emailAddress)>\r\n\
+            To: "\(receiver.name ?? "")" <\(receiver.emailAddress)>\r\n\
+            Date: \(date.formattedForSMTP)\r\n\
+            Message-ID: <\(date.timeIntervalSince1970)@\(senderServerName)>\r\n\
+            Subject: \(subject)\r\n\
+            MIME-Version: 1.0\r\n
+            """
+            #/Content-Type: multipart/alternative; boundary=([A-Za-z0-9]{32})\r\n/#
+            "\r\n"
+        }
+        let match = try #require(try regex.prefixMatch(in: encoded))
+        let boundary = String(match.output.1)
+
+        #expect(encoded[match.range.upperBound...] == """
+                --\(boundary)\r\n\
+                Content-Type: text/plain; charset="UTF-8"\r\n\r\n\
+                \(plainTextBody)\r\n\r\n\
+                --\(boundary)\r\n\
+                Content-Type: text/html; charset="UTF-8"\r\n\r\n\
+                \(htmlBody)\r\n\r\n\
+                --\(boundary)--\r\n\
+                \r\n.\r\n
+                """)
+    }
+}
+#endif


### PR DESCRIPTION
A new `Email.Attachment.Kind` decides what kind of attachment it is (inline vs. attachment). This is basically equivalent to the `Content-Disposition` header.

`inline` attachments _require_ a `contentID` (otherwise, they're basically useless since they can't be referenced).
Those of kind `attachment` also have a `contentID`, but it is optional.

With all this, the multipart encoding had to be updated to handle all cases (multipart/mixed, multipart/related, multipart/alternative). This is now implemented more cleanly and more correctly, too.

Resolves #114.