### PR TITLE
Add support for sending raw RFC 2822 message payloads

### DIFF
--- a/Sources/SwiftSMTP/Mailer.swift
+++ b/Sources/SwiftSMTP/Mailer.swift
@@ -1,9 +1,17 @@
 fileprivate import Dispatch
 import Foundation
+public import struct Foundation.Data
 public import NIO
 import NIOExtras
 import NIOSSL
 fileprivate import NIOConcurrencyHelpers
+
+fileprivate extension StringProtocol {
+    /// Whether the string contains a carriage return or line feed, either of which would allow SMTP command injection.
+    var containsCRorLF: Bool {
+        utf8.contains { $0 == 0x0D || $0 == 0x0A }
+    }
+}
 
 fileprivate extension Configuration.Server {
     enum EncryptionHandler {
@@ -25,8 +33,8 @@ fileprivate extension Configuration.Server {
 
 /// A Mailer is responsible for opening server connections and dispatching emails.
 public final class Mailer: Sendable {
-    private struct ScheduledEmail: Sendable {
-        let email: Email
+    private struct ScheduledSend: Sendable {
+        let sendJob: SendJob
         let promise: EventLoopPromise<Void>
     }
 
@@ -42,7 +50,7 @@ public final class Mailer: Sendable {
     private let connectionsSemaphore: DispatchSemaphore?
     private let senderQueue = DispatchQueue(label: "SMTP Mailer Sender Queue")
 
-    private let emailsStack = NIOLockedValueBox(Array<ScheduledEmail>())
+    private let sendsStack = NIOLockedValueBox(Array<ScheduledSend>())
 
     /// Creates a new mailer with the given parameters.
     /// - Parameters:
@@ -67,15 +75,15 @@ public final class Mailer: Sendable {
         }
     }
 
-    private func pushEmail(_ email: ScheduledEmail) {
-        emailsStack.withLockedValue { $0.append(email) }
+    private func pushSend(_ scheduled: ScheduledSend) {
+        sendsStack.withLockedValue { $0.append(scheduled) }
     }
 
-    private func popEmail() -> ScheduledEmail? {
-        emailsStack.withLockedValue { $0.isEmpty ? nil : $0.removeFirst() }
+    private func popSend() -> ScheduledSend? {
+        sendsStack.withLockedValue { $0.isEmpty ? nil : $0.removeFirst() }
     }
 
-    private func connectBootstrap(sending email: ScheduledEmail) {
+    private func connectBootstrap(sending scheduled: ScheduledSend) {
         let bootstrap = ClientBootstrap(group: group)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .connectTimeout(configuration.connectionTimeOut)
@@ -95,7 +103,7 @@ public final class Mailer: Sendable {
                             base64EncodeAllMessages: configuration.featureFlags.contains(.base64EncodeAllMessages),
                             base64EncodingOptions: base64Options
                         )),
-                        SMTPHandler(configuration: configuration, email: email.email, allDonePromise: email.promise),
+                        SMTPHandler(configuration: configuration, sendJob: scheduled.sendJob, allDonePromise: scheduled.promise),
                     ]
                     if let logger = transmissionLogger {
                         func makeLogHandler<Logger: SMTPLogger>(_ logger: Logger) -> LogDuplexHandler<Logger> {
@@ -114,8 +122,8 @@ public final class Mailer: Sendable {
                 }
             }
         let connectionFuture = bootstrap.connect(host: configuration.server.hostname, port: configuration.server.port)
-        connectionFuture.cascadeFailure(to: email.promise)
-        email.promise.futureResult.whenComplete { [weak self] _ in
+        connectionFuture.cascadeFailure(to: scheduled.promise)
+        scheduled.promise.futureResult.whenComplete { [weak self] _ in
             connectionFuture.whenSuccess { $0.close(mode: .all, promise: nil) }
             guard let self else { return }
             self.connectionsSemaphore?.signal()
@@ -124,7 +132,7 @@ public final class Mailer: Sendable {
     }
 
     private func scheduleMailDelivery() {
-        guard let next = popEmail() else { return }
+        guard let next = popSend() else { return }
         senderQueue.async { [weak self] in
             self?.connectionsSemaphore?.wait()
             self?.connectBootstrap(sending: next)
@@ -132,9 +140,16 @@ public final class Mailer: Sendable {
     }
 
     @usableFromInline
-    func _sendFuture(for email: Email) -> EventLoopFuture<Void> {
+    func _sendFuture(for sendJob: SendJob) -> EventLoopFuture<Void> {
+        // Guard every send path: a job with no recipients would make the handler send `DATA` with no
+        // preceding `RCPT TO`, violating RFC 5321 §3.3. Fail the future rather than trapping, since the
+        // public `send(_:)` email overload can reach here with an empty `Email` in release builds (the
+        // `Email` recipients check is an `assert`, which is compiled out).
+        guard !sendJob.recipients.isEmpty else {
+            return group.next().makeFailedFuture(MissingRecipientsError())
+        }
         let promise = group.next().makePromise(of: Void.self)
-        pushEmail(ScheduledEmail(email: email, promise: promise))
+        pushSend(ScheduledSend(sendJob: sendJob, promise: promise))
         scheduleMailDelivery()
         return promise.futureResult
     }
@@ -144,13 +159,58 @@ public final class Mailer: Sendable {
     /// - Returns: A future that will complete with the result of sending the email.
     @inlinable
     public func send(_ email: Email) -> EventLoopFuture<Void> {
-        _sendFuture(for: email)
+        _sendFuture(for: SendJob(email: email))
     }
 
     /// Schedules an email for delivery. Returns when once the email is successfully sent, or throws any error that occurrs during sending.
     /// - Parameter email: The email to send.
     public func send(_ email: Email) async throws {
-        try await _sendFuture(for: email).get()
+        try await send(email).get()
+    }
+
+    /// Schedules a pre-built RFC 2822 message payload for delivery, using the given SMTP envelope.
+    ///
+    /// Use this overload when the caller already owns the canonical RFC 2822 bytes for the message, e.g. when the same bytes
+    /// must be delivered to SMTP `DATA` and stored verbatim via IMAP `APPEND`, when the message has been DKIM-signed and
+    /// must not be re-serialised, or when forwarding a message retrieved from another mail store.
+    ///
+    /// The SMTP envelope (`from` / `to`) is independent of the RFC 2822 `From:` / `To:` headers. Pass the actual SMTP envelope
+    /// here — typically including any BCC recipients that do not appear in the headers.
+    ///
+    /// The encoder applies dot-stuffing per RFC 5321 §4.5.2 and adds a trailing `<CRLF>` to the payload before the
+    /// `<CRLF>.<CRLF>` terminator if the payload does not already end with one. Bare LFs in the payload pass through
+    /// unchanged — strict servers may reject such payloads.
+    ///
+    /// The envelope addresses must not contain a carriage return or line feed; either would let arbitrary SMTP
+    /// commands be injected into the session. Such addresses are rejected up front with `InvalidEnvelopeAddressError`.
+    ///
+    /// No maximum message size is enforced. The entire payload is buffered in memory while it is encoded, so the
+    /// caller is responsible for keeping the message within a size their environment and server can handle.
+    ///
+    /// - Parameters:
+    ///   - messageData: The full RFC 2822 message bytes (headers, blank line, body). Caller is responsible for content; this method does not validate or transform the headers.
+    ///   - from: The envelope sender (used for `MAIL FROM`). Must not contain CR or LF.
+    ///   - to: The envelope recipients (used for `RCPT TO`). Must be non-empty and must not contain CR or LF.
+    /// - Returns: A future that will complete with the result of sending the message. Fails immediately with `MissingRecipientsError` if `to` is empty, or `InvalidEnvelopeAddressError` if any envelope address contains CR or LF.
+    public func send(_ messageData: Data, from: String, to: Array<String>) -> EventLoopFuture<Void> {
+        // Reject CR/LF before opening a connection; the empty-recipients case is caught by `_sendFuture`.
+        for address in [from] + to where address.containsCRorLF {
+            return group.next().makeFailedFuture(InvalidEnvelopeAddressError(address: address))
+        }
+        return _sendFuture(for: SendJob(sender: from, recipients: to, payload: .rawData(messageData)))
+    }
+
+    /// Schedules a pre-built RFC 2822 message payload for delivery, using the given SMTP envelope.
+    ///
+    /// See ``send(_:from:to:)-9z6kg`` for the design rationale and contract; this is the async-throwing variant.
+    ///
+    /// - Parameters:
+    ///   - messageData: The full RFC 2822 message bytes (headers, blank line, body).
+    ///   - from: The envelope sender (used for `MAIL FROM`). Must not contain CR or LF.
+    ///   - to: The envelope recipients (used for `RCPT TO`). Must be non-empty and must not contain CR or LF.
+    /// - Throws: `MissingRecipientsError` if `to` is empty, `InvalidEnvelopeAddressError` if any envelope address contains CR or LF; otherwise any error that occurs during sending.
+    public func send(_ messageData: Data, from: String, to: Array<String>) async throws {
+        try await send(messageData, from: from, to: to).get()
     }
 }
 

--- a/Sources/SwiftSMTP/Models/NetworkModels.swift
+++ b/Sources/SwiftSMTP/Models/NetworkModels.swift
@@ -1,3 +1,4 @@
+internal import struct Foundation.Data
 internal import struct Foundation.Date
 
 enum SMTPRequest: Sendable {
@@ -10,7 +11,29 @@ enum SMTPRequest: Sendable {
     case recipient(String)
     case data
     case transferData(date: Date, email: Email)
+    case transferRawData(Data)
     case quit
 }
 
 typealias SMTPResponse = Result<(Int, String), ServerError>
+
+@usableFromInline
+struct SendJob: Sendable {
+    enum Payload: Sendable {
+        case email(Email)
+        case rawData(Data)
+    }
+
+    let sender: String
+    let recipients: Array<String>
+    let payload: Payload
+}
+
+extension SendJob {
+    @usableFromInline
+    init(email: Email) {
+        self.init(sender: email.sender.emailAddress,
+                  recipients: email.allRecipients.map(\.emailAddress),
+                  payload: .email(email))
+    }
+}

--- a/Sources/SwiftSMTP/Models/SMTPErrors.swift
+++ b/Sources/SwiftSMTP/Models/SMTPErrors.swift
@@ -12,3 +12,22 @@ public struct ServerError: Error, CustomStringConvertible {
 
     public var description: String { "Received an error from the server: \(serverMessage)" }
 }
+
+/// Thrown when a message is scheduled for sending without any recipients.
+@DebugDescription
+public struct MissingRecipientsError: Error, CustomStringConvertible {
+    public var description: String { "At least one recipient is required to send a message." }
+}
+
+/// Thrown when an envelope address (used for `MAIL FROM` / `RCPT TO`) contains a carriage return or line
+/// feed. Such characters would allow additional SMTP commands to be injected into the session, so they are
+/// rejected before any connection is opened.
+// Note: no `@DebugDescription` here. The description must escape the embedded CR/LF (otherwise it could forge
+// extra log lines), and that macro only allows plain stored-property interpolation in the description.
+public struct InvalidEnvelopeAddressError: Error, CustomStringConvertible {
+    /// The offending address.
+    public let address: String
+
+    // Render the address escaped so the embedded CR/LF cannot forge extra log lines.
+    public var description: String { "Envelope address must not contain CR or LF characters: \(String(reflecting: address))" }
+}

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPHandler.swift
@@ -16,7 +16,7 @@ fileprivate extension SMTPResponse {
 
 final class SMTPHandler: ChannelInboundHandler {
     typealias InboundIn = SMTPResponse
-    typealias OutboundIn = Email
+    typealias OutboundIn = SendJob
     typealias OutboundOut = SMTPRequest
 
     private enum State: Sendable {
@@ -27,20 +27,20 @@ final class SMTPHandler: ChannelInboundHandler {
         case usernameSent(Configuration.Credentials)
         case passwordSent
         case mailFromSent
-        case recipientSent(IndexingIterator<Array<Email.Contact>>)
+        case recipientSent(IndexingIterator<Array<String>>)
         case dataCommandSent
         case mailDataSent
         case quitSent
     }
 
     private let configuration: Configuration
-    private let email: Email
+    private let sendJob: SendJob
     private let allDonePromise: EventLoopPromise<Void>
     private var state = State.idle(didSend: false)
 
-    init(configuration: Configuration, email: Email, allDonePromise: EventLoopPromise<Void>) {
+    init(configuration: Configuration, sendJob: SendJob, allDonePromise: EventLoopPromise<Void>) {
         self.configuration = configuration
-        self.email = email
+        self.sendJob = sendJob
         self.allDonePromise = allDonePromise
     }
 
@@ -59,9 +59,9 @@ final class SMTPHandler: ChannelInboundHandler {
         }
 #endif
 
-        func nextState(for iterator: inout IndexingIterator<Array<Email.Contact>>) -> State {
+        func nextState(for iterator: inout IndexingIterator<Array<String>>) -> State {
             if let next = iterator.next() {
-                send(command: .recipient(next.emailAddress))
+                send(command: .recipient(next))
                 return .recipientSent(iterator)
             } else {
                 send(command: .data)
@@ -77,7 +77,7 @@ final class SMTPHandler: ChannelInboundHandler {
                 send(command: .beginAuthentication)
                 return .authBegan(creds)
             } else {
-                send(command: .mailFrom(email.sender.emailAddress))
+                send(command: .mailFrom(sendJob.sender))
                 return .mailFromSent
             }
         }
@@ -100,15 +100,20 @@ final class SMTPHandler: ChannelInboundHandler {
             send(command: .authPassword(credentials.password))
             state = .passwordSent
         case .passwordSent:
-            send(command: .mailFrom(email.sender.emailAddress))
+            send(command: .mailFrom(sendJob.sender))
             state = .mailFromSent
         case .mailFromSent:
-            var iterator = email.allRecipients.makeIterator()
+            var iterator = sendJob.recipients.makeIterator()
             state = nextState(for: &iterator)
         case .recipientSent(var iterator):
             state = nextState(for: &iterator)
         case .dataCommandSent:
-            send(command: .transferData(date: Date(), email: email))
+            switch sendJob.payload {
+            case .email(let email):
+                send(command: .transferData(date: Date(), email: email))
+            case .rawData(let messageData):
+                send(command: .transferRawData(messageData))
+            }
             state = .mailDataSent
         case .mailDataSent:
             send(command: .quit)

--- a/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
+++ b/Sources/SwiftSMTP/NIO Channel Handlers/SMTPRequestEncoder.swift
@@ -65,6 +65,34 @@ struct SMTPRequestEncoder: MessageToByteEncoder {
         return Data(text.utf8).base64EncodedString(options: base64EncodingOptions)
     }
 
+    private func endsWithCRLF(_ data: Data) -> Bool {
+        data.last == 0x0A && data.dropLast().last == 0x0D
+    }
+
+    /// Writes `data` to `out`, doubling any `.` byte that appears at the start of a line.
+    /// Per RFC 5321 §4.5.2 — the receiving server strips the leading dot to recover the original payload.
+    /// "Start of line" means the byte at offset 0 of the payload, or any byte immediately following a CRLF.
+    /// A `.` following a bare CR or bare LF is left untouched: SMTP lines are CRLF-delimited, so a receiver
+    /// frames such a dot mid-line and does not un-stuff it. Doubling it there would corrupt the payload.
+    private func writeDotStuffed(_ data: Data, to out: inout ByteBuffer) {
+        // Write contiguous runs in bulk, only breaking to insert an extra dot at a line-leading `.`.
+        // Payloads with no leading dots (the common case) are written in a single `writeBytes`.
+        var atStartOfLine = true
+        var previousByte: UInt8 = 0
+        var segmentStart = data.startIndex
+        for index in data.indices {
+            let byte = data[index]
+            if atStartOfLine && byte == 0x2E /* . */ {
+                out.writeBytes(data[segmentStart...index]) // flush the run up to and including the dot
+                out.writeInteger(UInt8(0x2E))               // then the extra stuffing dot, giving `..`
+                segmentStart = data.index(after: index)
+            }
+            atStartOfLine = byte == 0x0A && previousByte == 0x0D
+            previousByte = byte
+        }
+        out.writeBytes(data[segmentStart...])
+    }
+
     func encode(data: OutboundIn, out: inout ByteBuffer) throws {
         func writeLine(_ line: String, lineEndings: Int = 1) {
             out.writeString(line + String(repeating: "\r\n", count: lineEndings))
@@ -167,6 +195,12 @@ struct SMTPRequestEncoder: MessageToByteEncoder {
             }
 
             out.writeString("\r\n.") // second \r\n is added at the very end of the function
+        case .transferRawData(let messageData):
+            writeDotStuffed(messageData, to: &out)
+            if !endsWithCRLF(messageData) {
+                out.writeString("\r\n")
+            }
+            out.writeString(".") // final \r\n is added at the very end of the function
         case .quit:
             out.writeString("QUIT")
         }

--- a/Tests/SwiftSMTPTests/MailerSendRawDataTests.swift
+++ b/Tests/SwiftSMTPTests/MailerSendRawDataTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+import NIO
+import NIOPosix
+@testable import SwiftSMTP
+
+@Suite
+struct MailerSendRawDataTests {
+    @Test
+    func emptyRecipientsFutureFailsImmediately() async throws {
+        // Empty `to` must fail with MissingRecipientsError without opening a connection.
+        // The async overload delegates to this future via .get(), so this covers both surfaces.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let mailer = Mailer(
+            group: group,
+            configuration: .init(server: .init(hostname: "smtp.example.invalid"))
+        )
+
+        let future: EventLoopFuture<Void> = mailer.send(Data(), from: "sender@example.com", to: [])
+        await #expect(throws: MissingRecipientsError.self) {
+            try await future.get()
+        }
+
+        try await group.shutdownGracefully()
+    }
+
+    @Test(arguments: [
+        // sender carrying an injected RCPT TO command
+        ("a@b.com>\r\nRCPT TO:<victim@evil.com", ["c@d.com"]),
+        // recipient carrying an injected command
+        ("a@b.com", ["c@d.com>\r\nDATA\r\ninjected"]),
+        // bare LF is enough to break the line as well
+        ("a@b.com", ["c@d.com\nRCPT TO:<x@y.com"]),
+    ] as [(String, [String])])
+    func crOrLFInEnvelopeIsRejected(from: String, to: [String]) async throws {
+        // A CR or LF in an envelope address would let the caller inject extra SMTP commands. These must be
+        // rejected before any connection is opened.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let mailer = Mailer(
+            group: group,
+            configuration: .init(server: .init(hostname: "smtp.example.invalid"))
+        )
+
+        let future: EventLoopFuture<Void> = mailer.send(Data("body\r\n".utf8), from: from, to: to)
+        await #expect(throws: InvalidEnvelopeAddressError.self) {
+            try await future.get()
+        }
+
+        try await group.shutdownGracefully()
+    }
+}

--- a/Tests/SwiftSMTPTests/SMTPHandlerTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPHandlerTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+import NIO
+@testable import SwiftSMTP
+
+@Suite
+struct SMTPHandlerTests {
+    private func makeEmail(recipients: Array<String>,
+                           cc: Array<String> = [],
+                           bcc: Array<String> = []) -> Email {
+        Email(sender: .init(emailAddress: "sender@example.com"),
+              recipients: recipients.map { .init(emailAddress: $0) },
+              cc: cc.map { .init(emailAddress: $0) },
+              bcc: bcc.map { .init(emailAddress: $0) },
+              subject: "Subject",
+              body: .plain("Body"))
+    }
+
+    /// Feeds the handler `responseCount` successful server responses, one channel read at a time, and
+    /// collects the command it emits in reaction to each. Plain server, no credentials, so the flow is
+    /// HELLO → MAIL FROM → RCPT TO* → DATA → transfer → QUIT.
+    private func commands(for sendJob: SendJob, responseCount: Int) throws -> Array<String> {
+        let channel = EmbeddedChannel()
+        let promise = channel.eventLoop.makePromise(of: Void.self)
+        let handler = SMTPHandler(configuration: .init(server: .init(hostname: "smtp.example.invalid")),
+                                  sendJob: sendJob,
+                                  allDonePromise: promise)
+        try channel.pipeline.syncOperations.addHandler(handler)
+
+        var emitted = Array<String>()
+        for _ in 0..<responseCount {
+            try channel.writeInbound(SMTPResponse.success((250, "OK")))
+            while let command = try channel.readOutbound(as: SMTPRequest.self) {
+                emitted.append(Self.describe(command))
+            }
+        }
+        promise.succeed(())
+        _ = try? channel.finish()
+        return emitted
+    }
+
+    private static func describe(_ request: SMTPRequest) -> String {
+        switch request {
+        case .sayHello: "HELLO"
+        case .startTLS: "STARTTLS"
+        case .beginAuthentication: "AUTH"
+        case .authUser: "AUTH_USER"
+        case .authPassword: "AUTH_PASSWORD"
+        case .mailFrom(let from): "MAIL FROM:\(from)"
+        case .recipient(let rcpt): "RCPT TO:\(rcpt)"
+        case .data: "DATA"
+        case .transferData: "TRANSFER_DATA"
+        case .transferRawData: "TRANSFER_RAW_DATA"
+        case .quit: "QUIT"
+        }
+    }
+
+    @Test
+    func emailPathUsesSenderAndAllRecipientsForEnvelope() throws {
+        // Guards the SendJob refactor: the envelope must come from the sender plus the full recipient set
+        // (to + cc + bcc), and the data phase must use the email transfer branch.
+        let email = makeEmail(recipients: ["to@example.com"],
+                              cc: ["cc@example.com"],
+                              bcc: ["bcc@example.com"])
+        let emitted = try commands(for: SendJob(email: email), responseCount: 8)
+        #expect(emitted == [
+            "HELLO",
+            "MAIL FROM:sender@example.com",
+            "RCPT TO:to@example.com",
+            "RCPT TO:cc@example.com",
+            "RCPT TO:bcc@example.com",
+            "DATA",
+            "TRANSFER_DATA",
+            "QUIT",
+        ])
+    }
+
+    @Test
+    func rawDataPathUsesGivenEnvelopeAndRawTransfer() throws {
+        // The raw-bytes path must drive the same envelope sequence but take the transferRawData branch.
+        let sendJob = SendJob(sender: "envelope@example.com",
+                              recipients: ["one@example.com", "two@example.com"],
+                              payload: .rawData(Data("From: x\r\n\r\nBody\r\n".utf8)))
+        let emitted = try commands(for: sendJob, responseCount: 7)
+        #expect(emitted == [
+            "HELLO",
+            "MAIL FROM:envelope@example.com",
+            "RCPT TO:one@example.com",
+            "RCPT TO:two@example.com",
+            "DATA",
+            "TRANSFER_RAW_DATA",
+            "QUIT",
+        ])
+    }
+}

--- a/Tests/SwiftSMTPTests/SMTPRequestEncoderRawDataTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPRequestEncoderRawDataTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import Foundation
+import NIO
+@testable import SwiftSMTP
+
+@Suite
+struct SMTPRequestEncoderRawDataTests {
+    private func encodeRawData(_ messageData: Data) throws -> String {
+        let encoder = SMTPRequestEncoder(base64EncodeAllMessages: false, base64EncodingOptions: [])
+        var byteBuffer = ByteBufferAllocator().buffer(capacity: 1024)
+        try encoder.encode(data: .transferRawData(messageData), out: &byteBuffer)
+        return byteBuffer.readString(length: byteBuffer.readableBytes) ?? ""
+    }
+
+    @Test
+    func dotStuffingAtFirstLine() async throws {
+        let payload = Data(".start\r\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "..start\r\n.\r\n")
+    }
+
+    @Test
+    func dotStuffingMidPayload() async throws {
+        let payload = Data("\r\nfoo\r\n.test\r\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "\r\nfoo\r\n..test\r\n.\r\n")
+    }
+
+    @Test
+    func multipleDotLinesAreAllStuffed() async throws {
+        let payload = Data(".one\r\n.two\r\n.three\r\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "..one\r\n..two\r\n..three\r\n.\r\n")
+    }
+
+    @Test
+    func nonLeadingDotsAreUntouched() async throws {
+        let payload = Data("a.b.c\r\nx.y.z\r\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "a.b.c\r\nx.y.z\r\n.\r\n")
+    }
+
+    @Test
+    func trailingCRLFAddedWhenMissing() async throws {
+        let payload = Data("body without terminator".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "body without terminator\r\n.\r\n")
+    }
+
+    @Test
+    func trailingCRLFNotDoubledWhenPresent() async throws {
+        let payload = Data("body with terminator\r\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "body with terminator\r\n.\r\n")
+    }
+
+    @Test
+    func bareLFPassesThroughUnchanged() async throws {
+        // Caller may have crafted exact bytes (DKIM, IMAP APPEND parity) — encoder must not canonicalise.
+        let payload = Data("line1\nline2\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "line1\nline2\n\r\n.\r\n")
+    }
+
+    @Test
+    func dotAfterBareLFIsNotStuffed() async throws {
+        // A '.' is only at "start of line" after a CRLF. Following a bare LF it is mid-line as far as a
+        // CRLF-framing receiver is concerned, so doubling it would corrupt the payload (the receiver would
+        // not un-stuff it). Stuffing only the true CRLF-led dot is what keeps DKIM-signed bodies intact.
+        let payload = Data("foo\n.bar\r\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "foo\n.bar\r\n.\r\n")
+    }
+
+    @Test
+    func dotAfterCRLFIsStuffedEvenAdjacentToBareLF() async throws {
+        // Contrast with the bare-LF case: a dot that does follow a CRLF must still be stuffed.
+        let payload = Data("foo\n\r\n.bar\r\n".utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == "foo\n\r\n..bar\r\n.\r\n")
+    }
+
+    @Test
+    func emptyPayloadProducesEmptyMessage() async throws {
+        // Empty data → just the dot terminator on its own line; servers are expected to reject but the encoder should not crash.
+        let encoded = try encodeRawData(Data())
+        #expect(encoded == "\r\n.\r\n")
+    }
+
+    @Test
+    func rfc2822LikeMessageRoundTrips() async throws {
+        // Realistic shape: headers + blank line + body + trailing CRLF. Should pass through bit-identical
+        // (no header/body separator munging, no body line rewriting).
+        let payload = Data("""
+            From: sender@example.com\r\n\
+            To: receiver@example.com\r\n\
+            Subject: Hello\r\n\
+            \r\n\
+            Body line 1\r\n\
+            Body line 2\r\n
+            """.utf8)
+        let encoded = try encodeRawData(payload)
+        #expect(encoded == String(data: payload, encoding: .utf8)! + ".\r\n")
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Mailer.send(_:from:to:)` overloads (future-based and async) that accept a pre-built RFC 2822 message as raw bytes, bypassing the `Email` model and its MIME encoding.

This is useful when the caller already owns the canonical message bytes and must transmit them verbatim, for example:

- DKIM-signed messages, where re-serialising would break the signature.
- Messages that must be delivered to SMTP `DATA` and also stored via IMAP `APPEND` with identical bytes.
- Forwarding a message retrieved from another mail store.

The SMTP envelope (`from` / `to`) is passed explicitly and is independent of the RFC 2822 `From:` / `To:` headers, so callers can include BCC recipients that do not appear in the headers.

## Changes

- Refactor `SMTPHandler` to operate on a `SendJob` abstraction so the data phase can carry either an `Email` or raw bytes.
- Add a `transferRawData` branch to `SMTPRequestEncoder`. Dot-stuffing per RFC 5321 §4.5.2 is applied only at true CRLF line boundaries, so a `.` following a bare CR or LF is left untouched (doubling it would corrupt byte-exact payloads such as DKIM-signed bodies). A trailing `<CRLF>` is added before the `<CRLF>.<CRLF>` terminator only when the payload does not already end with one.
- Add `Mailer.send` overloads taking the raw message plus explicit envelope sender/recipients. Envelope addresses containing CR or LF are rejected with `InvalidEnvelopeAddressError` to prevent SMTP command injection; an empty recipient list fails with `MissingRecipientsError`.

## Tests

- `SMTPRequestEncoderRawDataTests`: dot-stuffing (first-line, mid-payload, multiple, bare-LF, CRLF-adjacent-to-bare-LF), trailing-CRLF handling, empty payload, and a realistic RFC 2822 round-trip.
- `MailerSendRawDataTests`: empty-recipient failure and CR/LF envelope rejection.
- `SMTPHandlerTests`: full `EmbeddedChannel` state-machine drive asserting the envelope command sequence for both the email and raw-data paths.

All tests pass locally (SPM, macOS).